### PR TITLE
Openbsd support

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -33,6 +33,12 @@ CFLAGS-add+=-fPIC
 FFLAGS-add+=-fPIC
 endif
 
+ifeq ($(OS), OpenBSD)
+SHLIB_EXT = so
+CFLAGS-add+=-fPIC
+FFLAGS-add+=-fPIC
+endif
+
 ifeq ($(OS), Darwin)
 SHLIB_EXT = dylib
 CFLAGS-add+=-fPIC

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 all:
-	make -C src
+	$(MAKE) -C src
 
 clean:
-	make -C src clean
+	$(MAKE) -C src clean

--- a/README.md
+++ b/README.md
@@ -28,3 +28,9 @@ julia> [rand(Uniform()), rand(Uniform())]
  0.236033
  0.346517
 ````
+
+Build instructions
+------------------
+
+Rmath-julia requires GNU Make (https://www.gnu.org/software/make). Just run
+`make` to compile the library.


### PR DESCRIPTION
I've modified the Makefiles a bit in order to make the library compilable under OpenBSD. If one installs GNU Make via the port system, the executable is named `gmake` and therefore one should run the following command:

    gmake MAKE=gmake

I have added a paragraph at the end of the `Makefile` to explain this trick. 