### PR TITLE
WIP: automatically build binaries on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: c
+os:
+  - linux
+  - osx
+script:
+  - make -j3
+deploy:
+  provider: releases
+  api_key: "$OATH_TOKEN"
+  file: "src/libRmath-julia.*"
+  file_glob: true
+  skip_cleanup: true
+  on:
+    tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: c
 os:
   - linux
   - osx
+notifications:
+  email: false
 script:
   - make -j3
 deploy:


### PR DESCRIPTION
This is part of what I showed in my JuliaCon tutorial, but only handles 64 bit Ubuntu 12.04, and Mac OS X. I'll be improving this by adding docker builders for generic Linux, and Windows cross-compile.
